### PR TITLE
Update dependencies versions to fix unexpected failure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,30 +24,30 @@ checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+checksum = "a3a318f1f38d2418400f8209655bfd825785afd25aa30bb7ba6cc792e4596748"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -64,9 +64,9 @@ checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "clap"
-version = "4.4.10"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fffed7514f420abec6d183b1d3acfd9099c79c3a10a06ade4f8203f1411272"
+checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.9"
+version = "4.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63361bae7eef3771745f02d8d892bec2fee5f6e34af316ba556e7f97a7069ff1"
+checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -173,8 +173,7 @@ checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 [[package]]
 name = "pagemap"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b10bd736861cab1e4a800e7547d08f5103929b3549a45a23408aaff0c1ee71"
+source = "git+https://github.com/tramasys/pagemap-rs?branch=patch#7f4869454d63119dbd92b68a539f37e04d45b722"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.4.10", features = ["derive"] }
 colored = "2.0.4"
-pagemap = "0.1.0"
+pagemap = { git = "https://github.com/tramasys/pagemap-rs", branch = "patch" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,8 @@ fn dump_maps_hdr() {
 fn dump_maps_entry(entry: &MapsEntry) {
     println!(
         "{:<64} {:<8} {:<10} {:<10} {:<10} {}", 
-        entry.memory_region().to_string(), 
+        // entry.memory_region().to_string(), 
+        entry.vma().to_string(),
         entry.permissions().to_string(), 
         entry.offset().to_string(), 
         entry.device_numbers().to_string(), 
@@ -102,14 +103,14 @@ fn main() {
     let entry = addr
         .as_ref()
         .and_then(|addr| {
-            entries.iter().find(|(entry, _)| entry.memory_region().contains(*addr))
+            entries.iter().find(|(entry, _)| entry.vma().contains(*addr))
         });
 
     match (addr, entry) {
         (Some(addr), Some((maps_entry, pmap_entry))) => {
             // dump_maps_hdr();
             // dump_maps_entry(maps_entry);
-            let region = maps_entry.memory_region();
+            let region = maps_entry.vma();
             if cli.all {
                 dump_pmaps_hdr();
                 for idx in 0..pmap_entry.len() as u64 {


### PR DESCRIPTION
Ref: https://github.com/ckatsak/pagemap-rs/pull/1
Fix an unexpected bug like the following, 
```
could not read '/proc/2813443/pagemap': failed to fill whole buffer
```